### PR TITLE
Remove dependency in ext-json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [1.3.0] - 2026-01-07
 ### Added
 * *Nothing*
 
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ### Removed
 * Drop support for PHP 8.3
+* Remove explicit dependency in `ext-json`, since it's part of PHP since v8.0
 
 ### Fixed
 * *Nothing*

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
         }
     ],
     "require": {
-        "php": "^8.4",
-        "ext-json": "*"
+        "php": "^8.4"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1",


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink/issues/2565

Remove explicit dependency in `ext-json`, since it's part of PHP since v8.0